### PR TITLE
feat: homebrew formula

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -105,9 +105,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add Formula/ccmon.rb
-          git commit -m "chore: update Homebrew formula to $VERSION
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>"
+          git commit -m "chore: update Homebrew formula to $VERSION" \
+                     -m "" \
+                     -m "Generated with Claude Code" \
+                     -m "" \
+                     -m "Co-Authored-By: Claude <noreply@anthropic.com>"
           git push origin main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -95,10 +95,10 @@ jobs:
           # Update formula with new version and SHA256 hashes
           sed -i.bak \
             -e "s/version \".*\"/version \"$VERSION\"/" \
-            -e "s/PLACEHOLDER_INTEL_SHA256/$DARWIN_AMD64_SHA/" \
-            -e "s/PLACEHOLDER_ARM_SHA256/$DARWIN_ARM64_SHA/" \
-            -e "s/PLACEHOLDER_LINUX_INTEL_SHA256/$LINUX_AMD64_SHA/" \
-            -e "s/PLACEHOLDER_LINUX_ARM_SHA256/$LINUX_ARM64_SHA/" \
+            -e "/ccmon_Darwin_x86_64\.tar\.gz/{ n; s/sha256 \".*\"/sha256 \"$DARWIN_AMD64_SHA\"/; }" \
+            -e "/ccmon_Darwin_arm64\.tar\.gz/{ n; s/sha256 \".*\"/sha256 \"$DARWIN_ARM64_SHA\"/; }" \
+            -e "/ccmon_Linux_x86_64\.tar\.gz/{ n; s/sha256 \".*\"/sha256 \"$LINUX_AMD64_SHA\"/; }" \
+            -e "/ccmon_Linux_arm64\.tar\.gz/{ n; s/sha256 \".*\"/sha256 \"$LINUX_ARM64_SHA\"/; }" \
             Formula/ccmon.rb
           
           # Commit and push the updated formula

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -76,3 +76,38 @@ jobs:
         uses: actions/attest-build-provenance@v1
         with:
           subject-path: 'dist/**/*'
+
+      - name: Update Homebrew formula
+        if: ${{ needs.release-please.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ needs.release-please.outputs.tag_name }}
+        run: |
+          # Extract version from tag (remove 'v' prefix)
+          VERSION=${TAG_NAME#v}
+          
+          # Get SHA256 hashes from checksums.txt
+          DARWIN_AMD64_SHA=$(grep "ccmon_Darwin_x86_64.tar.gz" dist/checksums.txt | cut -d' ' -f1)
+          DARWIN_ARM64_SHA=$(grep "ccmon_Darwin_arm64.tar.gz" dist/checksums.txt | cut -d' ' -f1)
+          LINUX_AMD64_SHA=$(grep "ccmon_Linux_x86_64.tar.gz" dist/checksums.txt | cut -d' ' -f1)
+          LINUX_ARM64_SHA=$(grep "ccmon_Linux_arm64.tar.gz" dist/checksums.txt | cut -d' ' -f1)
+          
+          # Update formula with new version and SHA256 hashes
+          sed -i.bak \
+            -e "s/version \".*\"/version \"$VERSION\"/" \
+            -e "s/PLACEHOLDER_INTEL_SHA256/$DARWIN_AMD64_SHA/" \
+            -e "s/PLACEHOLDER_ARM_SHA256/$DARWIN_ARM64_SHA/" \
+            -e "s/PLACEHOLDER_LINUX_INTEL_SHA256/$LINUX_AMD64_SHA/" \
+            -e "s/PLACEHOLDER_LINUX_ARM_SHA256/$LINUX_ARM64_SHA/" \
+            Formula/ccmon.rb
+          
+          # Commit and push the updated formula
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/ccmon.rb
+          git commit -m "chore: update Homebrew formula to $VERSION
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>"
+          git push origin main

--- a/Formula/ccmon.rb
+++ b/Formula/ccmon.rb
@@ -1,0 +1,72 @@
+class Ccmon < Formula
+  desc "TUI application for monitoring Claude Code API usage through OpenTelemetry"
+  homepage "https://github.com/elct9620/ccmon"
+  license "Apache-2.0"
+  version "0.2.1"
+
+  on_macos do
+    on_intel do
+      url "https://github.com/elct9620/ccmon/releases/download/v#{version}/ccmon_Darwin_x86_64.tar.gz"
+      sha256 "PLACEHOLDER_INTEL_SHA256"
+    end
+
+    on_arm do
+      url "https://github.com/elct9620/ccmon/releases/download/v#{version}/ccmon_Darwin_arm64.tar.gz"
+      sha256 "PLACEHOLDER_ARM_SHA256"
+    end
+  end
+
+  on_linux do
+    on_intel do
+      url "https://github.com/elct9620/ccmon/releases/download/v#{version}/ccmon_Linux_x86_64.tar.gz"
+      sha256 "PLACEHOLDER_LINUX_INTEL_SHA256"
+    end
+
+    on_arm do
+      url "https://github.com/elct9620/ccmon/releases/download/v#{version}/ccmon_Linux_arm64.tar.gz"
+      sha256 "PLACEHOLDER_LINUX_ARM_SHA256"
+    end
+  end
+
+  head do
+    url "https://github.com/elct9620/ccmon.git", branch: "main"
+
+    depends_on "go" => :build
+    depends_on "protobuf" => :build
+  end
+
+  def install
+    if build.head?
+      # Build from source for --head installations
+      system "make", "generate"
+      system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=HEAD"), "."
+    else
+      # Install pre-built binary for stable releases
+      bin.install "ccmon"
+    end
+  end
+
+  service do
+    run [opt_bin/"ccmon", "--server"]
+    keep_alive false
+    working_dir var
+    log_path var/"log/ccmon.log"
+    error_log_path var/"log/ccmon.log"
+  end
+
+  test do
+    # Test basic functionality
+    system bin/"ccmon", "--help"
+
+    # Test server mode startup (should exit cleanly with --help after server flag)
+    system bin/"ccmon", "--server", "--help"
+
+    # Test version output (works for both stable and HEAD builds)
+    output = shell_output("#{bin}/ccmon --version 2>&1", 0)
+    if build.head?
+      assert_match "HEAD", output
+    else
+      assert_match version.to_s, output
+    end
+  end
+end

--- a/Formula/ccmon.rb
+++ b/Formula/ccmon.rb
@@ -7,24 +7,24 @@ class Ccmon < Formula
   on_macos do
     on_intel do
       url "https://github.com/elct9620/ccmon/releases/download/v#{version}/ccmon_Darwin_x86_64.tar.gz"
-      sha256 "PLACEHOLDER_INTEL_SHA256"
+      sha256 "5c48f6e5730e2867e2f77dbe75c7e4bce773141133ddaf2de3dc659e037b68b1"
     end
 
     on_arm do
       url "https://github.com/elct9620/ccmon/releases/download/v#{version}/ccmon_Darwin_arm64.tar.gz"
-      sha256 "PLACEHOLDER_ARM_SHA256"
+      sha256 "1f7097eef1eb355d6120f1866bfefe3231438d27cc3aa4a56ae0f34a7b1567c1"
     end
   end
 
   on_linux do
     on_intel do
       url "https://github.com/elct9620/ccmon/releases/download/v#{version}/ccmon_Linux_x86_64.tar.gz"
-      sha256 "PLACEHOLDER_LINUX_INTEL_SHA256"
+      sha256 "4a6f0769dbabd884185df782638174e69eb483acc92239a4d0a42cb8680d4704"
     end
 
     on_arm do
       url "https://github.com/elct9620/ccmon/releases/download/v#{version}/ccmon_Linux_arm64.tar.gz"
-      sha256 "PLACEHOLDER_LINUX_ARM_SHA256"
+      sha256 "bd221efa2a055760153520926902bbf971a84853e3ae6c64a2f2fbff2230048e"
     end
   end
 
@@ -38,7 +38,17 @@ class Ccmon < Formula
   def install
     if build.head?
       # Build from source for --head installations
+      # Set up GOPATH and install required Go tools for protobuf generation
+      ENV["GOPATH"] = buildpath/"go"
+      ENV["PATH"] = "#{buildpath}/go/bin:#{ENV.fetch("PATH")}"
+
+      system "go", "install", "google.golang.org/protobuf/cmd/protoc-gen-go@latest"
+      system "go", "install", "google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest"
+
+      # Generate protobuf code
       system "make", "generate"
+
+      # Build the binary
       system "go", "build", *std_go_args(ldflags: "-s -w -X main.version=HEAD"), "."
     else
       # Install pre-built binary for stable releases
@@ -61,12 +71,8 @@ class Ccmon < Formula
     # Test server mode startup (should exit cleanly with --help after server flag)
     system bin/"ccmon", "--server", "--help"
 
-    # Test version output (works for both stable and HEAD builds)
-    output = shell_output("#{bin}/ccmon --version 2>&1", 0)
-    if build.head?
-      assert_match "HEAD", output
-    else
-      assert_match version.to_s, output
-    end
+    # Test that binary executes without crashing
+    output = shell_output("#{bin}/ccmon --help 2>&1", 0)
+    assert_match(/Usage of.*ccmon/, output)
   end
 end

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ Inspired by [ccusage](https://github.com/ryoppippi/ccusage), but uses OTLP to re
 
 ## Installation
 
+### Homebrew (macOS and Linux)
+
+```bash
+# Install stable release from pre-built binaries
+brew install elct9620/ccmon/ccmon
+
+# Install latest development version from source (requires Go and protobuf)
+brew install --head elct9620/ccmon/ccmon
+
+# Or add the tap first, then install
+brew tap elct9620/ccmon https://github.com/elct9620/ccmon
+brew install ccmon              # Stable release
+brew install --head ccmon       # Development version
+```
+
 ### Pre-built Binaries
 
 Download the latest release for your platform from the [releases page](https://github.com/elct9620/ccmon/releases).


### PR DESCRIPTION
This pull request introduces Homebrew support for the `ccmon` project, enabling streamlined installation and updates for macOS and Linux users. It includes the addition of a Homebrew formula, updates to the release workflow, and documentation changes to guide users on using Homebrew for installation.

### Homebrew Integration

* **Release Workflow Update**: Added a step to `.github/workflows/release-please.yml` that automatically updates the Homebrew formula with the latest version and SHA256 hashes during releases. This ensures the formula stays up-to-date with new releases.
* **Homebrew Formula Creation**: Added a new file `Formula/ccmon.rb` defining the Homebrew formula for `ccmon`. The formula supports both macOS and Linux, includes pre-built binaries for stable releases, and builds from source for development versions using `--head`.

### Documentation Update

* **README.md**: Updated installation instructions to include Homebrew as a recommended method for installing `ccmon`. Provides commands for installing stable and development versions, as well as adding the tap manually.