### PR TITLE
docs(homebrew): clarify installation instructions with tap addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,14 @@ Inspired by [ccusage](https://github.com/ryoppippi/ccusage), but uses OTLP to re
 ### Homebrew (macOS and Linux)
 
 ```bash
-# Install stable release from pre-built binaries
-brew install elct9620/ccmon/ccmon
-
-# Install latest development version from source (requires Go and protobuf)
-brew install --head elct9620/ccmon/ccmon
-
-# Or add the tap first, then install
+# Add the tap from the main repository
 brew tap elct9620/ccmon https://github.com/elct9620/ccmon
-brew install ccmon              # Stable release
-brew install --head ccmon       # Development version
+
+# Install stable release from pre-built binaries
+brew install ccmon
+
+# Or install latest development version from source (requires Go and protobuf)
+brew install --head ccmon
 ```
 
 ### Pre-built Binaries


### PR DESCRIPTION
## Summary
- Clarify Homebrew installation instructions by showing tap addition first
- Streamline the installation flow for better user experience
- Remove redundant examples and consolidate into clearer steps

## Changes
- Move `brew tap` command to the top as the first step
- Simplify the installation examples
- Remove duplicate installation patterns
- Make the flow: tap → install stable → or install head

## Before
```bash
# Install stable release from pre-built binaries
brew install elct9620/ccmon/ccmon

# Install latest development version from source (requires Go and protobuf)
brew install --head elct9620/ccmon/ccmon

# Or add the tap first, then install
brew tap elct9620/ccmon https://github.com/elct9620/ccmon
brew install ccmon              # Stable release
brew install --head ccmon       # Development version
```

## After
```bash
# Add the tap from the main repository
brew tap elct9620/ccmon https://github.com/elct9620/ccmon

# Install stable release from pre-built binaries
brew install ccmon

# Or install latest development version from source (requires Go and protobuf)
brew install --head ccmon
```

## Benefits
- ✅ Clearer installation flow
- ✅ Reduced duplication and confusion
- ✅ Follows standard Homebrew tap → install pattern
- ✅ Maintains all installation options (stable + head)

🤖 Generated with [Claude Code](https://claude.ai/code)